### PR TITLE
Check return code of FindErrors in Decode

### DIFF
--- a/include/rs.hpp
+++ b/include/rs.hpp
@@ -143,6 +143,8 @@ public:
         const uint8_t src_len = msg_length + ecc_length;
         const uint8_t dst_len = msg_length;
 
+        bool ok;
+
         /* Allocation memory on stack */
         uint8_t stack_memory[MSG_CNT * msg_length + POLY_CNT * ecc_length * 2];
         this->memory = stack_memory;
@@ -201,7 +203,8 @@ public:
         }
 
         // Fing errors
-        FindErrors(reloc, src_len);
+        ok = FindErrors(reloc, src_len);
+        if(!ok) return 1;
 
         // Error happened while finding errors (so helpfull :D)
         if(err->length == 0) return 1;


### PR DESCRIPTION
In cases where the errors could not be corrected (but were detected) make sure Decode returns an error, so that the calling code knows that errors were detected, but could not be corrected.

You can test this by modifying the example. Add one more `E` so that it can't correct the error and check the return value of Decode:

    char message[] = "Some very important message ought to be delivered";
    const int msglen = sizeof(message);
    const int ecclen = 8;
    const int nErrors = 5;
    
    char repaired[msglen];
    char encoded[msglen + ecclen];


    RS::ReedSolomon<msglen, ecclen> rs;

    rs.Encode(message, encoded);

    // Corrupting first 8 bytes of message (any 4 bytes can be repaired, no more)
    for(uint i = 0; i < nErrors; i++) {
        encoded[i] = 'E';
    }

    int ok = rs.Decode(encoded, repaired);
    if (ok != 0) {
        std::cout << "Couldn't repair the data" << std::endl;
        return;
    }

    std::cout << "Original:  " << message  << std::endl;
    std::cout << "Corrupted: " << encoded  << std::endl;
    std::cout << "Repaired:  " << repaired << std::endl;

    std::cout << ((memcmp(message, repaired, msglen) == 0) ? "SUCCESS" : "FAILURE") << std::endl;

For `nErrors == 5` this will fail the `memcmp` test but `Decode` will claim it was successful. (For other values of `nErrors`, for example `6`, it might be the case that `Decode` will return an error, but for others it also won't.)

My patch fixes this example so that the caller can determine whether this was successful or not.

Otherwise many thanks for writing this!