### PR TITLE
Improve flags to allow subproject specific debug configuration

### DIFF
--- a/include/gf.hpp
+++ b/include/gf.hpp
@@ -9,7 +9,7 @@
 #include <string.h>
 #include "poly.hpp"
 
-#if !defined DEBUG && !defined __CC_ARM
+#if !defined RS_DEBUG && !defined __CC_ARM
 #include <assert.h>
 #else
 #define assert(dummy)

--- a/include/gf.hpp
+++ b/include/gf.hpp
@@ -9,7 +9,7 @@
 #include <string.h>
 #include "poly.hpp"
 
-#if !defined RS_DEBUG && !defined __CC_ARM
+#if !defined RS_DEBUG && !defined __CC_ARM && !defined RS_NO_ASSERT
 #include <assert.h>
 #else
 #define assert(dummy)

--- a/include/poly.hpp
+++ b/include/poly.hpp
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if !defined DEBUG && !defined __CC_ARM
+#if !defined RS_DEBUG && !defined __CC_ARM
 #include <assert.h>
 #else
 #define assert(dummy)

--- a/include/poly.hpp
+++ b/include/poly.hpp
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if !defined RS_DEBUG && !defined __CC_ARM
+#if !defined RS_DEBUG && !defined __CC_ARM && !defined RS_NO_ASSERT
 #include <assert.h>
 #else
 #define assert(dummy)

--- a/include/rs.hpp
+++ b/include/rs.hpp
@@ -10,7 +10,7 @@
 #include "poly.hpp"
 #include "gf.hpp"
 
-#if !defined DEBUG && !defined __CC_ARM
+#if !defined RS_DEBUG && !defined __CC_ARM
 #include <assert.h>
 #else
 #define assert(dummy)
@@ -237,7 +237,7 @@ public:
          return DecodeBlock(src, ecc_ptr, dst, erase_pos, erase_count);
      }
 
-#ifndef DEBUG
+#ifndef RS_DEBUG
 private:
 #endif
 

--- a/include/rs.hpp
+++ b/include/rs.hpp
@@ -10,7 +10,7 @@
 #include "poly.hpp"
 #include "gf.hpp"
 
-#if !defined RS_DEBUG && !defined __CC_ARM
+#if !defined RS_DEBUG && !defined __CC_ARM && !defined RS_NO_ASSERT
 #include <assert.h>
 #else
 #define assert(dummy)


### PR DESCRIPTION
Hello there,

we have been using this library for a while now as a submodule in a student project of ours and it works like a charm. However our project has become enormous in size and relies on multiple submodules.

### New Features

This pull request introduces two small changes to preprocessor directives:

1. Add the `RS_` prefix to the debug macro. This allows specifying that only the debug flag in the Reed-Solomon submodule is set and not for the whole project.
2. Add the `RS_NO_ASSERT` macro. Our project will later run on an STM32L4 Microcontroller and therefore can only use freestanding libraries. With this flag we could disable including `<assert.h>` without having to set the debug flag.

### Breaking changes

The first change might break some interfaces, that rely on the `DEBUG` macro. If this is not manageable i could also remove this renaming.

Also we think with the `__CC_ARM` you wanted to remove non-freestanding libraries when cross-compiling for an arm-microcontroller. In case this is true, let me suggest using the `__STDC_HOSTED__` directive instead (see [cppreference](https://en.cppreference.com/w/cpp/freestanding)). This is set to 0 by the compiler when using a freestanding implementation and can be used to determine whether to include `<assert.h>` for a broader target than just cc_arm.